### PR TITLE
Modified the conditional rendering logic to ensure that state names are displayed when either hovered over or selected

### DIFF
--- a/src/lib/components/AssetsHistogram.svelte
+++ b/src/lib/components/AssetsHistogram.svelte
@@ -9,7 +9,6 @@
 	// sort and get the quantiles of the data
 	// sort and get the quantiles of the data
 	let sortedData = sort(data, (a, b) => Number(a.total_assets) - Number(b.total_assets));
-	console.log(sortedData);
 	let q1 = quantile(sortedData, 0.25, (d) => Number(d.total_assets));
 	let median = quantile(sortedData, 0.5, (d) => Number(d.total_assets));
 	let q3 = quantile(sortedData, 0.75, (d) => Number(d.total_assets));

--- a/src/lib/components/Map.svelte
+++ b/src/lib/components/Map.svelte
@@ -230,16 +230,18 @@
 					{#each states.features as feature}
 						<GeoPath geojson={feature} let:geoPath>
 							{@const [x, y] = geoPath.centroid(feature)}
-							{#if $selectedConstituency && $selectedConstituency.ls_seat_name === feature.properties.ls_seat_name}
+							{#if (hovered === feature || ($selectedConstituency && $selectedConstituency.ls_seat_name === feature.properties.ls_seat_name))}
 								<Text
-									{x}
+									x={x}
 									scaleToFit
 									y={y - 20}
 									value={feature.properties.ls_seat_name}
 									textAnchor="middle"
 									verticalAnchor="start"
 									class=" stroke-surface-100 font-serif  text-[5px] stroke-[2px] shadow-md"
-								/>
+								>
+									{feature.properties.ls_seat_name}
+								</Text>
 							{/if}
 						</GeoPath>
 					{/each}


### PR DESCRIPTION
Remove console.log in AssetsHistogram.svelte
Modified the conditional rendering logic to ensure that state names are displayed when either hovered over or selected